### PR TITLE
依存関係のバージョンを上げた

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,8 +125,8 @@ dependencies {
     testImplementation "io.github.takahirom.roborazzi:roborazzi:1.8.0-alpha-3"
     testImplementation "io.github.takahirom.roborazzi:roborazzi-compose:1.8.0-alpha-3"
     testImplementation "io.github.takahirom.roborazzi:roborazzi-junit-rule:1.8.0-alpha-3"
-    testImplementation "io.mockk:mockk-android:${mockkVersion}"
-    testImplementation "io.mockk:mockk-agent:${mockkVersion}"
+    testImplementation "io.mockk:mockk-android:$mockkVersion"
+    testImplementation "io.mockk:mockk-agent:$mockkVersion"
     testImplementation 'androidx.compose.ui:ui-test-junit4'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ apollo {
 android {
 
     namespace 'com.yuta.cocktailmaster'
-    compileSdk 33
+    compileSdk 34
 
     testOptions {
         unitTests {
@@ -27,7 +27,7 @@ android {
     defaultConfig {
         applicationId "com.yuta.cocktailmaster"
         minSdk 26
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -93,15 +93,15 @@ android {
 }
 
 dependencies {
-    def nav_version = "2.5.3"
+    def nav_version = "2.7.5"
     def room_version = "2.5.0"
-    def lifecycle_version = "2.5.1"
+    def lifecycle_version = "2.6.2"
     def mockkVersion = "1.13.8"
 
-    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.0')
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.5.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
+    implementation 'androidx.activity:activity-compose:1.8.1'
     implementation platform('androidx.compose:compose-bom:2022.10.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
@@ -110,7 +110,7 @@ dependencies {
 
     implementation "androidx.navigation:navigation-compose:$nav_version"
     implementation "androidx.room:room-runtime:$room_version"
-    implementation "androidx.room:room-ktx:2.5.2"
+    implementation "androidx.room:room-ktx:$room_version"
     // To use Kotlin Symbol Processing (KSP)
     ksp "androidx.room:room-compiler:$room_version"
     // ViewModel utilities for Compose


### PR DESCRIPTION
## 概要
- roomだけは最新にするとkspのエラーがでて、それを解決するとkotlinとcomposeのバージョンが合わなくなりエラーがでるんでバージョンを上げなかった
## スクショ

## 補足情報

- [x] 動作確認をした
- [ ] テストを書いた