### PR TITLE
タブレットの画面サイズに対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,6 +142,7 @@ dependencies {
     implementation libs.datastore.preference
     implementation libs.constraint.layout
     implementation libs.apollo.runtime
+    implementation libs.material3.window.size
 
     testImplementation libs.junit
     testImplementation libs.robolectric

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,9 @@ datastorePreferece = "1.0.0"
 constraintLayout = "1.0.1"
 apolloRuntime = "3.8.2"
 
+# runtime only
+material3WindowSizeClass = "1.2.0-alpha11"
+
 # test
 junit = "4.13.2"
 robolectric = "4.11.1"
@@ -56,6 +59,10 @@ retrofit2-kotlin-serialization-converter = { group = "com.jakewharton.retrofit",
 datastore-preference = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastorePreferece" }
 constraint-layout = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "constraintLayout" }
 apollo-runtime = { group = "com.apollographql.apollo3", name = "apollo-runtime", version.ref = "apolloRuntime" }
+
+# runtime only
+material3-window-size = { group = "androidx.compose.material3", name = "material3-window-size-class", version.ref = "material3WindowSizeClass" }
+
 
 # test
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## 概要
- 現状でもタブレットでアプリを実行できるが、スマホを基準に作っているため違和感のあるレイアウトになる
## スクショ

タブレット版の雑なレイアウト図
| トップ画面 | カクテル一覧画面 |
| :--: |  :--: |
![Draft-カクテル一覧画面](https://github.com/SEKI-YUTA/CocktailMaster_JetpackCompose/assets/56211510/3cbcdd05-9a58-47be-abda-f0c144b7055a) | ![Draft-トップ画面](https://github.com/SEKI-YUTA/CocktailMaster_JetpackCompose/assets/56211510/03addfde-3695-43fc-8089-e559cc4bc134)

figma
https://www.figma.com/file/75p0dretq0v8WzRBJ5I6Jo/CocktialMaster%E3%82%BF%E3%83%96%E3%83%AC%E3%83%83%E3%83%88%E3%83%AC%E3%82%A4%E3%82%A2%E3%82%A6%E3%83%88?type=design&node-id=0-1&mode=design&t=3uJK0AIvelzg3wwi-0

## 補足情報

- [ ] 動作確認をした
- [ ] テストを書いた